### PR TITLE
fix(Create main.py per docs):

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -91,6 +91,8 @@ INFO:     Uvicorn running on http://127.0.0.1:8718 (Press CTRL+C to quit)
 
 Import the necessary packages and create your FastAPI app:
 
+In `main.py`,
+
 ```python
 
 from fastapi import FastAPI

--- a/main.py
+++ b/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+from langcorn import create_service
+
+app: FastAPI = create_service(
+    "examples.ex1:chain",
+    "examples.ex2:chain",
+    "examples.ex3:chain",
+    "examples.ex4:sequential_chain",
+    "examples.ex5:conversation",
+    "examples.ex6:conversation_with_summary",
+)


### PR DESCRIPTION
Wasn't able to run `uvicorn main:app` explicitly without having a `main.py` file. 

Current main throws this error:

`ERROR:    Error loading ASGI app. Could not import module "main".`

Documentation is not clear that this file needs to exist.